### PR TITLE
Fix for issues #106 and #79

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -152,7 +152,7 @@ if ( ! class_exists( 'Yoast_GA_Frontend' ) ) {
 						if ( count( $out_links ) >= 1 ) {
 							foreach ( $out_links as $out ) {
 								if ( ! empty( $original_url ) && ! empty( $domain['domain'] ) ) {
-									if ( strpos( $original_url, $domain['domain'] . $out ) !== false ) {
+									if ( $out && strpos( $original_url, $domain['domain'] . $out ) !== false ) {
 										$type = 'internal-as-outbound';
 									}
 								}


### PR DESCRIPTION
Cater for null values so that we don't create "outbound-article-int" on tracking on internal links.