### PR TITLE
Improve the way the fail to fetch notice has been triggered.

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -148,13 +148,7 @@ if ( ! class_exists( 'Yoast_GA_Admin' ) ) {
 		 * @return bool
 		 */
 		private function show_admin_warning() {
-			if ( current_user_can( 'manage_options' ) ) {
-				if ( ! isset( $_GET['page'] ) || ( isset( $_GET['page'] ) && $_GET['page'] !== 'yst_ga_settings' ) ) {
-					return true;
-				}
-			}
-
-			return false;
+			return ( current_user_can( 'manage_options' ) && ( ! isset( $_GET['page'] ) || ( isset( $_GET['page'] ) && $_GET['page'] !== 'yst_ga_settings' ) ) );
 		}
 
 		/**

--- a/admin/class-google-analytics.php
+++ b/admin/class-google-analytics.php
@@ -326,7 +326,7 @@ if ( ! class_exists( 'Yoast_Google_Analytics_Notice', false ) ) {
 		public static function warning_fetching_data_authenticate() {
 			self::show_error(
 				sprintf(
-					__( 'Failed to fetch the new data from Google Analytics. You might need to %sreauthenticate%s.', 'google-analytics-for-wordpress' ),
+					__( 'It seems the authentication for the plugin has expired, please %sre-authenticate%s with Google Analytics to allow the plugin to fetch data.', 'google-analytics-for-wordpress' ),
 					'<a href="' . admin_url( 'admin.php?page=yst_ga_settings' ) . '">',
 					'</a>'
 				)
@@ -338,7 +338,11 @@ if ( ! class_exists( 'Yoast_Google_Analytics_Notice', false ) ) {
 		 */
 		public static function warning_fetching_data() {
 			self::show_error(
-				__( 'Failed to fetch the new data from Google Analytics. This might be caused by a problem with the Google service.', 'google-analytics-for-wordpress' )
+				sprintf(
+					__( 'Data is not up-to-date, there was an error in retrieving the data from Google Analytics. This error could be caused by several issues. If the error persists, please see %sthis page%s.', 'google-analytics-for-wordpress' ),
+					'<a href="http://yoa.st/2p">',
+					'</a>'
+				)
 			);
 		}
 

--- a/admin/class-google-analytics.php
+++ b/admin/class-google-analytics.php
@@ -312,21 +312,43 @@ if ( ! class_exists( 'Yoast_Google_Analytics_Notice', false ) ) {
 		 * Throw a warning if no UA code is set.
 		 */
 		public static function config_warning() {
-			echo '<div class="error"><p>' . sprintf( __( 'Please configure your %sGoogle Analytics settings%s!', 'google-analytics-for-wordpress' ), '<a href="' . admin_url( 'admin.php?page=yst_ga_settings' ) . '">', '</a>' ) . '</p></div>';
+			self::show_error(
+				sprintf( __( 'Please configure your %sGoogle Analytics settings%s!', 'google-analytics-for-wordpress' ),
+					'<a href="' . admin_url( 'admin.php?page=yst_ga_settings' ) . '">',
+					'</a>'
+				)
+			);
 		}
 
 		/**
 		 * Throw a warning when the fetching failed
 		 */
 		public static function warning_fetching_data_authenticate() {
-			echo '<div class="error"><p>' . sprintf( __( 'Failed to fetch the new data from Google Analytics. You might need to %sreauthenticate%s.', 'google-analytics-for-wordpress' ), '<a href="' . admin_url( 'admin.php?page=yst_ga_settings' ) . '">', '</a>' ) . '</p></div>';
+			self::show_error(
+				sprintf(
+					__( 'Failed to fetch the new data from Google Analytics. You might need to %sreauthenticate%s.', 'google-analytics-for-wordpress' ),
+					'<a href="' . admin_url( 'admin.php?page=yst_ga_settings' ) . '">',
+					'</a>'
+				)
+			);
 		}
 
 		/**
 		 * Throw a warning when the fetching failed
 		 */
 		public static function warning_fetching_data() {
-			echo '<div class="error"><p>' . __( 'Failed to fetch the new data from Google Analytics. This might be caused by a problem with the Google service.', 'google-analytics-for-wordpress' ) . '</p></div>';
+			self::show_error(
+				__( 'Failed to fetch the new data from Google Analytics. This might be caused by a problem with the Google service.', 'google-analytics-for-wordpress' )
+			);
+		}
+
+		/**
+		 * Showing the given error as an error div
+		 *
+		 * @param $error_message
+		 */
+		private static function show_error( $error_message ) {
+			echo '<div class="error"><p>' . $error_message . '</p></div>';
 		}
 
 	}

--- a/admin/class-google-analytics.php
+++ b/admin/class-google-analytics.php
@@ -57,12 +57,38 @@ if ( ! class_exists( 'Yoast_Google_Analytics', false ) ) {
 			return self::$instance;
 		}
 
+
+		/**
+		 * Check if something went wrong with API calls to Google Analytics
+		 */
+		public function check_for_ga_issues() {
+
+			$last_run   = get_option( 'yst_ga_last_wp_run' );
+			$has_failed = get_option( 'yst_ga_api_call_fail', false );
+
+			// Show error, something went wrong
+			if ( $has_failed && ( $last_run === false || Yoast_GA_Utils::hours_between( strtotime( $last_run ), time() ) >= 48 ) ) {
+				$notice_type = 'warning_fetching_data';
+
+				// Authentication has been successful, so there will be an access token
+				if ( ! $this->client->getAccessToken() ) {
+					$notice_type .= '_authenticate';
+				}
+
+				add_action( 'admin_notices', array( 'Yoast_Google_Analytics_Notice', $notice_type ) );
+			}
+
+		}
+
 		/**
 		 * Wrapper for authenticate the client. If authentication code is send it will get and check an access token.
 		 *
 		 * @param mixed $authentication_code
 		 */
 		public function authenticate( $authentication_code = null ) {
+			// When authentication again we should clean up some stuff
+			$this->api_cleanup();
+
 			$this->client->authenticate_client( $authentication_code );
 		}
 
@@ -202,7 +228,7 @@ if ( ! class_exists( 'Yoast_Google_Analytics', false ) ) {
 		 *
 		 * @return bool
 		 */
-		private function test_connection_to_google(){
+		private function test_connection_to_google() {
 			$wp_http = new WP_Http();
 			if ( $wp_http->block_request( 'https://www.googleapis.com/analytics/v3/management/accountSummaries' ) === false ) {
 				return true;
@@ -265,6 +291,42 @@ if ( ! class_exists( 'Yoast_Google_Analytics', false ) ) {
 			}
 
 			return false;
+		}
+
+		/**
+		 * Doing some clean up when this method is called
+		 */
+		private function api_cleanup() {
+			delete_option( 'yst_ga_api_call_fail' );
+		}
+
+	}
+
+}
+
+if ( ! class_exists( 'Yoast_Google_Analytics_Notice', false ) ) {
+
+	class Yoast_Google_Analytics_Notice {
+
+		/**
+		 * Throw a warning if no UA code is set.
+		 */
+		public static function config_warning() {
+			echo '<div class="error"><p>' . sprintf( __( 'Please configure your %sGoogle Analytics settings%s!', 'google-analytics-for-wordpress' ), '<a href="' . admin_url( 'admin.php?page=yst_ga_settings' ) . '">', '</a>' ) . '</p></div>';
+		}
+
+		/**
+		 * Throw a warning when the fetching failed
+		 */
+		public static function warning_fetching_data_authenticate() {
+			echo '<div class="error"><p>' . sprintf( __( 'Failed to fetch the new data from Google Analytics. You might need to %sreauthenticate%s.', 'google-analytics-for-wordpress' ), '<a href="' . admin_url( 'admin.php?page=yst_ga_settings' ) . '">', '</a>' ) . '</p></div>';
+		}
+
+		/**
+		 * Throw a warning when the fetching failed
+		 */
+		public static function warning_fetching_data() {
+			echo '<div class="error"><p>' . __( 'Failed to fetch the new data from Google Analytics. This might be caused by a problem with the Google service.', 'google-analytics-for-wordpress' ) . '</p></div>';
 		}
 
 	}

--- a/admin/dashboards/class-admin-dashboards-collector.php
+++ b/admin/dashboards/class-admin-dashboards-collector.php
@@ -119,18 +119,14 @@ if ( ! class_exists( 'Yoast_GA_Dashboards_Collector' ) ) {
 		public function check_api_call_hook( ) {
 			$last_run = $this->get_last_aggregate_run();
 
-			if ( $last_run === false ) {
-				/**
-				 * Transient doesn't exists, so we need to run the
-				 * hook (This function runs already on Shutdown so
-				 * we can call it directly from now on)
-				 */
+
+			/**
+			 * Transient doesn't exists, so we need to run the
+			 * hook (This function runs already on Shutdown so
+			 * we can call it directly from now on) or the last run has ben more than 24 hours
+			 */
+			if ( $last_run === false || Yoast_GA_Utils::hours_between( strtotime( $last_run ), time() ) >= 24 ) {
 				$this->aggregate_data();
-			} else {
-				// Transient exists
-				if ( Yoast_GA_Utils::hours_between( strtotime( $last_run ), time() ) >= 24 ) {
-					$this->aggregate_data();
-				}
 			}
 		}
 

--- a/admin/dashboards/class-admin-dashboards-collector.php
+++ b/admin/dashboards/class-admin-dashboards-collector.php
@@ -289,10 +289,7 @@ if ( ! class_exists( 'Yoast_GA_Dashboards_Collector' ) ) {
 		 *
 		 */
 		private function save_api_failure() {
-			$attempts = get_option('yst_ga_api_call_fail', false );
-			if( ! $attempts ) {
-				update_option( 'yst_ga_api_call_fail', true );
-			}
+			update_option( 'yst_ga_api_call_fail', true );
 		}
 
 		/**

--- a/includes/class-autoload.php
+++ b/includes/class-autoload.php
@@ -26,6 +26,7 @@ if ( ! class_exists( 'Yoast_GA_Autoload' ) ) {
 					'yoast_ga_admin'                      => 'admin/class-admin',
 					'yoast_ga_admin_menu'                 => 'admin/class-admin-menu',
 					'yoast_google_analytics'              => 'admin/class-google-analytics',
+					'yoast_google_analytics_notice'       => 'admin/class-google-analytics',
 					'yoast_ga_admin_assets'               => 'admin/class-admin-assets',
 					'yoast_ga_admin_form'                 => 'admin/class-admin-form',
 

--- a/tests/test-class-admin.php
+++ b/tests/test-class-admin.php
@@ -44,30 +44,6 @@ class Yoast_GA_Admin_Test extends GA_UnitTestCase {
 	}
 
 	/**
-	 * Test a part of the config warning to make sure we have one
-	 */
-	public function test_config_warning() {
-		ob_start();
-		Yoast_Google_Analytics_Notice::config_warning();
-		$output   = ob_get_clean();
-		$expected = '<div class="error"><p>Please configure your <a href="' . admin_url( 'admin.php?page=yst_ga_settings' ) . '">Google Analytics settings</a>!</p></div>';
-
-		$this->assertEquals( $output, $expected );
-	}
-
-	/**
-	 * Test the warning fetching data to make sure we have one
-	 */
-	public function test_warning_fetching_data() {
-		ob_start();
-		$this->class_instance->warning_fetching_data();
-		$output   = ob_get_clean();
-		$expected = '<div class="error"><p>Failed to fetch the new data from Google Analytics. You might need to <a href="' . admin_url( 'admin.php?page=yst_ga_settings' ) . '">reauthenticate</a>.</p></div>';
-
-		$this->assertEquals( $output, $expected );
-	}
-
-	/**
 	 * Test user roles, we should get a few standard roles here. We also check if the role name is not empty
 	 *
 	 * @covers Yoast_GA_Admin::get_userroles()

--- a/tests/test-class-admin.php
+++ b/tests/test-class-admin.php
@@ -48,7 +48,7 @@ class Yoast_GA_Admin_Test extends GA_UnitTestCase {
 	 */
 	public function test_config_warning() {
 		ob_start();
-		$this->class_instance->config_warning();
+		Yoast_Google_Analytics_Notice::config_warning();
 		$output   = ob_get_clean();
 		$expected = '<div class="error"><p>Please configure your <a href="' . admin_url( 'admin.php?page=yst_ga_settings' ) . '">Google Analytics settings</a>!</p></div>';
 

--- a/tests/test-class-google-analytics-notice.php
+++ b/tests/test-class-google-analytics-notice.php
@@ -33,7 +33,7 @@ class Yoast_Google_Analytics_Notice_Test extends GA_UnitTestCase {
 		ob_start();
 		Yoast_Google_Analytics_Notice::warning_fetching_data_authenticate();
 		$output   = ob_get_clean();
-		$expected = '<div class="error"><p>It seems the authentication for the plugin has expired, please <a href="' . admin_url( 'admin.php?page=yst_ga_settings' ) . '">re-authenticate</a> with Google Analytics to allow the plugin to fetch data..</p></div>';
+		$expected = '<div class="error"><p>It seems the authentication for the plugin has expired, please <a href="' . admin_url( 'admin.php?page=yst_ga_settings' ) . '">re-authenticate</a> with Google Analytics to allow the plugin to fetch data.</p></div>';
 
 		$this->assertEquals( $output, $expected );
 	}

--- a/tests/test-class-google-analytics-notice.php
+++ b/tests/test-class-google-analytics-notice.php
@@ -31,7 +31,7 @@ class Yoast_Google_Analytics_Notice_Test extends GA_UnitTestCase {
 	 */
 	public function test_warning_fetching_data_authenticate() {
 		ob_start();
-		Yoast_Google_Analytics_Notice::warning_fetching_data();
+		Yoast_Google_Analytics_Notice::warning_fetching_data_authenticate();
 		$output   = ob_get_clean();
 		$expected = '<div class="error"><p>Failed to fetch the new data from Google Analytics. You might need to <a href="' . admin_url( 'admin.php?page=yst_ga_settings' ) . '">reauthenticate</a>.</p></div>';
 

--- a/tests/test-class-google-analytics-notice.php
+++ b/tests/test-class-google-analytics-notice.php
@@ -21,7 +21,7 @@ class Yoast_Google_Analytics_Notice_Test extends GA_UnitTestCase {
 		ob_start();
 		Yoast_Google_Analytics_Notice::warning_fetching_data();
 		$output   = ob_get_clean();
-		$expected = '<div class="error"><p>Failed to fetch the new data from Google Analytics. This might be caused by a problem with the Google service.</p></div>';
+		$expected = '<div class="error"><p>Data is not up-to-date, there was an error in retrieving the data from Google Analytics. This error could be caused by several issues. If the error persists, please see <a href="http://yoa.st/2p">this page</a>.</p></div>';
 
 		$this->assertEquals( $output, $expected );
 	}
@@ -33,7 +33,7 @@ class Yoast_Google_Analytics_Notice_Test extends GA_UnitTestCase {
 		ob_start();
 		Yoast_Google_Analytics_Notice::warning_fetching_data_authenticate();
 		$output   = ob_get_clean();
-		$expected = '<div class="error"><p>Failed to fetch the new data from Google Analytics. You might need to <a href="' . admin_url( 'admin.php?page=yst_ga_settings' ) . '">reauthenticate</a>.</p></div>';
+		$expected = '<div class="error"><p>It seems the authentication for the plugin has expired, please <a href="' . admin_url( 'admin.php?page=yst_ga_settings' ) . '">re-authenticate</a> with Google Analytics to allow the plugin to fetch data..</p></div>';
 
 		$this->assertEquals( $output, $expected );
 	}

--- a/tests/test-class-google-analytics-notice.php
+++ b/tests/test-class-google-analytics-notice.php
@@ -1,0 +1,42 @@
+<?php
+
+class Yoast_Google_Analytics_Notice_Test extends GA_UnitTestCase {
+
+	/**
+	 * Test a part of the config warning to make sure we have one
+	 */
+	public function test_config_warning() {
+		ob_start();
+		Yoast_Google_Analytics_Notice::config_warning();
+		$output   = ob_get_clean();
+		$expected = '<div class="error"><p>Please configure your <a href="' . admin_url( 'admin.php?page=yst_ga_settings' ) . '">Google Analytics settings</a>!</p></div>';
+
+		$this->assertEquals( $output, $expected );
+	}
+
+	/**
+	 * Test the warning fetching data to make sure we have one
+	 */
+	public function test_warning_fetching_data() {
+		ob_start();
+		Yoast_Google_Analytics_Notice::warning_fetching_data();
+		$output   = ob_get_clean();
+		$expected = '<div class="error"><p>Failed to fetch the new data from Google Analytics. This might be caused by a problem with the Google service.</p></div>';
+
+		$this->assertEquals( $output, $expected );
+	}
+
+	/**
+	 * Test the warning fetching data to make sure we have one
+	 */
+	public function test_warning_fetching_data_authenticate() {
+		ob_start();
+		Yoast_Google_Analytics_Notice::warning_fetching_data();
+		$output   = ob_get_clean();
+		$expected = '<div class="error"><p>Failed to fetch the new data from Google Analytics. You might need to <a href="' . admin_url( 'admin.php?page=yst_ga_settings' ) . '">reauthenticate</a>.</p></div>';
+
+		$this->assertEquals( $output, $expected );
+	}
+
+
+}


### PR DESCRIPTION
When entering the dashboards page after 48 hours there was a notice showing that there was a failure when fetching data. This is because of the check and fetching data will only happen on shutdown, when a user is on the GA settings or dashboard page. 
By adding an option that stores true for failure when API response returns a none 200 coded request, the notice will only be triggered when there is a real failure.

By checking the access_token we can be sure if user has been authenticated or not. So we can raise a notice when user hasn't been authenticated and there is a fallback notice for the other situation.

Last improvement is adding a notice class for Google Analytics notices. This should separate Google Analytics specific methods from the class-admin. 

@omarreiss or @jdevalk Could you code review this pull request?