### PR TITLE
Use standard universal tracking and fix for checkboxes in the admin form [Delivers #87502078]

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -51,26 +51,7 @@ class Yoast_GA_Admin extends Yoast_GA_Options {
 			Yoast_Google_Analytics::get_instance()->check_for_ga_issues();
 		}
 
-		if ( $_SERVER['REQUEST_METHOD'] == 'POST' ) {
-			if ( ! function_exists( 'wp_verify_nonce' ) ) {
-				require_once( ABSPATH . 'wp-includes/pluggable.php' );
-			}
-
-			if ( isset( $_POST['ga-form-settings'] ) && wp_verify_nonce( $_POST['yoast_ga_nonce'], 'save_settings' ) ) {
-				if ( ! isset ( $_POST['ignore_users'] ) ) {
-					$_POST['ignore_users'] = array();
-				}
-
-				$dashboards_disabled = Yoast_GA_Settings::get_instance()->dashboards_disabled();
-
-				if ( $dashboards_disabled == false && isset( $_POST['dashboards_disabled'] ) ) {
-					$dashboards->reset_dashboards_data();
-				}
-
-				// Post submitted and verified with our nonce
-				$this->save_settings( $_POST );
-			}
-		}
+		$this->handle_ga_post_request( $dashboards );
 
 		/**
 		 * Show the notifications if we have one
@@ -102,15 +83,7 @@ class Yoast_GA_Admin extends Yoast_GA_Options {
 		// Check checkboxes, on a uncheck they won't be posted to this function
 		$defaults = $this->default_ga_values();
 		foreach ( $defaults[$this->option_prefix] as $key => $value ) {
-			if ( ! isset( $data[$key] ) ) {
-				// If no data was passed in, set it to the default.
-				if ( $value === 1 ) {
-					// Disable the checkbox for now, use value 0
-					$this->options[$key] = 0;
-				} else {
-					$this->options[$key] = $value;
-				}
-			}
+			$this->handle_default_setting( $data, $key, $value );
 		}
 
 		if ( ! empty( $this->options['analytics_profile'] ) ) {
@@ -149,6 +122,53 @@ class Yoast_GA_Admin extends Yoast_GA_Options {
 		delete_option( 'yst_ga_accounts' );
 		delete_option( 'yst_ga_response' );
 
+	}
+
+	/**
+	 * Handle a default setting in GA
+	 *
+	 * @param $data
+	 * @param $key
+	 * @param $value
+	 */
+	private function handle_default_setting( $data, $key, $value ) {
+		if ( ! isset( $data[$key] ) ) {
+			// If no data was passed in, set it to the default.
+			if ( $value === 1 ) {
+				// Disable the checkbox for now, use value 0
+				$this->options[$key] = 0;
+			} else {
+				$this->options[$key] = $value;
+			}
+		}
+	}
+
+	/**
+	 * Handle the post requests in the admin form of the GA plugin
+	 *
+	 * @param $dashboards
+	 */
+	private function handle_ga_post_request( $dashboards ) {
+		if ( $_SERVER['REQUEST_METHOD'] == 'POST' ) {
+			if ( ! function_exists( 'wp_verify_nonce' ) ) {
+				require_once( ABSPATH . 'wp-includes/pluggable.php' );
+			}
+
+			if ( isset( $_POST['ga-form-settings'] ) && wp_verify_nonce( $_POST['yoast_ga_nonce'], 'save_settings' ) ) {
+				if ( ! isset ( $_POST['ignore_users'] ) ) {
+					$_POST['ignore_users'] = array();
+				}
+
+				$dashboards_disabled = Yoast_GA_Settings::get_instance()->dashboards_disabled();
+
+				if ( $dashboards_disabled == false && isset( $_POST['dashboards_disabled'] ) ) {
+					$dashboards->reset_dashboards_data();
+				}
+
+				// Post submitted and verified with our nonce
+				$this->save_settings( $_POST );
+			}
+		}
 	}
 
 	/**

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -51,7 +51,10 @@ class Yoast_GA_Admin extends Yoast_GA_Options {
 			Yoast_Google_Analytics::get_instance()->check_for_ga_issues();
 		}
 
-		$this->handle_ga_post_request( $dashboards );
+
+		if ( $_SERVER['REQUEST_METHOD'] == 'POST' ) {
+			$this->handle_ga_post_request( $dashboards );
+		}
 
 		/**
 		 * Show the notifications if we have one
@@ -149,25 +152,23 @@ class Yoast_GA_Admin extends Yoast_GA_Options {
 	 * @param $dashboards
 	 */
 	private function handle_ga_post_request( $dashboards ) {
-		if ( $_SERVER['REQUEST_METHOD'] == 'POST' ) {
-			if ( ! function_exists( 'wp_verify_nonce' ) ) {
-				require_once( ABSPATH . 'wp-includes/pluggable.php' );
+		if ( ! function_exists( 'wp_verify_nonce' ) ) {
+			require_once( ABSPATH . 'wp-includes/pluggable.php' );
+		}
+
+		if ( isset( $_POST['ga-form-settings'] ) && wp_verify_nonce( $_POST['yoast_ga_nonce'], 'save_settings' ) ) {
+			if ( ! isset ( $_POST['ignore_users'] ) ) {
+				$_POST['ignore_users'] = array();
 			}
 
-			if ( isset( $_POST['ga-form-settings'] ) && wp_verify_nonce( $_POST['yoast_ga_nonce'], 'save_settings' ) ) {
-				if ( ! isset ( $_POST['ignore_users'] ) ) {
-					$_POST['ignore_users'] = array();
-				}
+			$dashboards_disabled = Yoast_GA_Settings::get_instance()->dashboards_disabled();
 
-				$dashboards_disabled = Yoast_GA_Settings::get_instance()->dashboards_disabled();
-
-				if ( $dashboards_disabled == false && isset( $_POST['dashboards_disabled'] ) ) {
-					$dashboards->reset_dashboards_data();
-				}
-
-				// Post submitted and verified with our nonce
-				$this->save_settings( $_POST );
+			if ( $dashboards_disabled == false && isset( $_POST['dashboards_disabled'] ) ) {
+				$dashboards->reset_dashboards_data();
 			}
+
+			// Post submitted and verified with our nonce
+			$this->save_settings( $_POST );
 		}
 	}
 

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -85,8 +85,8 @@ class Yoast_GA_Admin extends Yoast_GA_Options {
 
 		// Check checkboxes, on a uncheck they won't be posted to this function
 		$defaults = $this->default_ga_values();
-		foreach ( $defaults[$this->option_prefix] as $key => $value ) {
-			$this->handle_default_setting( $data, $key, $value );
+		foreach ( $defaults[$this->option_prefix] as $option_name => $value ) {
+			$this->handle_default_setting( $data, $option_name, $value );
 		}
 
 		if ( ! empty( $this->options['analytics_profile'] ) ) {

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -131,17 +131,17 @@ class Yoast_GA_Admin extends Yoast_GA_Options {
 	 * Handle a default setting in GA
 	 *
 	 * @param $data
-	 * @param $key
+	 * @param $option_name
 	 * @param $value
 	 */
-	private function handle_default_setting( $data, $key, $value ) {
-		if ( ! isset( $data[$key] ) ) {
+	private function handle_default_setting( $data, $option_name, $value ) {
+		if ( ! isset( $data[$option_name] ) ) {
 			// If no data was passed in, set it to the default.
 			if ( $value === 1 ) {
 				// Disable the checkbox for now, use value 0
-				$this->options[$key] = 0;
+				$this->options[$option_name] = 0;
 			} else {
-				$this->options[$key] = $value;
+				$this->options[$option_name] = $value;
 			}
 		}
 	}

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -104,7 +104,12 @@ class Yoast_GA_Admin extends Yoast_GA_Options {
 		foreach ( $defaults[$this->option_prefix] as $key => $value ) {
 			if ( ! isset( $data[$key] ) ) {
 				// If no data was passed in, set it to the default.
-				$this->options[$key] = $value;
+				if ( $value === 1 ) {
+					// Disable the checkbox for now, use value 0
+					$this->options[$key] = 0;
+				} else {
+					$this->options[$key] = $value;
+				}
 			}
 		}
 

--- a/includes/class-options.php
+++ b/includes/class-options.php
@@ -246,7 +246,7 @@ class Yoast_GA_Options {
 				'track_internal_as_label'    => null,
 				'track_outbound'             => 0,
 				'anonymous_data'             => 0,
-				'enable_universal'           => 0,
+				'enable_universal'           => 1,
 				'demographics'               => 0,
 				'ignore_users'               => array( 'editor' ),
 				'dashboards_disabled'        => 0,


### PR DESCRIPTION
By default the old ga.js tracking was used, now we are using Universal tracking.

I've also fixed a related bug in the admin form, when you saved a checkbox with a default value 1, the checkbox was checked automatically again. For that, I've introduced a small check in the save_settings function to keep the checkbox unchecked.