### PR TITLE
Remove dashboard data when a new property is selected [Delivers #85875266]

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -163,13 +163,30 @@ class Yoast_GA_Admin extends Yoast_GA_Options {
 
 			$dashboards_disabled = Yoast_GA_Settings::get_instance()->dashboards_disabled();
 
-			if ( $dashboards_disabled == false && isset( $_POST['dashboards_disabled'] ) ) {
+			if ( ( $dashboards_disabled == false && isset( $_POST['dashboards_disabled'] ) ) || $this->detected_other_ga_property( $_POST ) ) {
 				$dashboards->reset_dashboards_data();
 			}
 
 			// Post submitted and verified with our nonce
 			$this->save_settings( $_POST );
 		}
+	}
+
+	/**
+	 * Is there selected an other property in the settings post? Returns true or false.
+	 *
+	 * @param $post
+	 *
+	 * @return bool
+	 */
+	private function detected_other_ga_property( $post ) {
+		if ( isset( $post['analytics_profile'] ) && isset( $this->options['analytics_profile'] ) ) {
+			if ( $post['analytics_profile'] != $this->options['analytics_profile'] ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -163,7 +163,7 @@ class Yoast_GA_Admin extends Yoast_GA_Options {
 
 			$dashboards_disabled = Yoast_GA_Settings::get_instance()->dashboards_disabled();
 
-			if ( ( $dashboards_disabled == false && isset( $_POST['dashboards_disabled'] ) ) || $this->detected_other_ga_property( $_POST ) ) {
+			if ( ( $dashboards_disabled == false && isset( $_POST['dashboards_disabled'] ) ) || $this->ga_profile_changed( $_POST ) ) {
 				$dashboards->reset_dashboards_data();
 			}
 
@@ -179,7 +179,7 @@ class Yoast_GA_Admin extends Yoast_GA_Options {
 	 *
 	 * @return bool
 	 */
-	private function detected_other_ga_property( $post ) {
+	private function ga_profile_changed( $post ) {
 		if ( isset( $post['analytics_profile'] ) && isset( $this->options['analytics_profile'] ) ) {
 			if ( $post['analytics_profile'] != $this->options['analytics_profile'] ) {
 				return true;


### PR DESCRIPTION
When the user selects a new web property in the settings, the dashboard data will be destroyed so we have new dashboard charts.