### PR TITLE
Added 'label_for' key to $args when callin add_settings_field

### DIFF
--- a/admin/class-admin-settings-fields.php
+++ b/admin/class-admin-settings-fields.php
@@ -22,7 +22,7 @@ class Yoast_GA_Admin_Settings_Fields {
 		self::set_options();
 		self::before_input( $args );
 
-		echo '<input type="text" name="yst_ga[ga_general][' . $args['key'] . ']" id="ga_form_' . $args['key'] . '" value="' . esc_attr( self::$options[ $args['key'] ] ) . '" class="ga-form-text">';
+		echo '<input type="text" name="yst_ga[ga_general][' . $args['key'] . ']" id="' . $args['label_for'] . '" value="' . esc_attr( self::$options[ $args['key'] ] ) . '" class="ga-form-text">';
 	}
 
 	/**
@@ -51,7 +51,7 @@ class Yoast_GA_Admin_Settings_Fields {
 		self::set_options();
 		self::before_input( $args );
 
-		echo '<input type="checkbox" name="yst_ga[ga_general][' . $args['key'] . ']" id="ga_form_' . $args['key'] . '" value="1" ' . checked( self::$options[ $args['key'] ], 1, false ) . '>';
+		echo '<input type="checkbox" name="yst_ga[ga_general][' . $args['key'] . ']" id="' . $args['label_for'] . '" value="1" ' . checked( self::$options[ $args['key'] ], 1, false ) . '>';
 	}
 
 	/**

--- a/admin/class-admin-settings-fields.php
+++ b/admin/class-admin-settings-fields.php
@@ -92,7 +92,7 @@ class Yoast_GA_Admin_Settings_Fields {
 			$options .= '<option value="' . esc_attr( $option['id'] ) . '" ' . selected( $option['id'], self::$options[ $args['key'] ], false ) . '>' . esc_attr( $option['name'] ) . '</option>';
 		}
 
-		echo self::show_help( 'id-' . $args['key'], $args['help'] ) . '<select id="ga_form_' . $args['key'] . '" name="yst_ga[ga_general][' . $args['key'] . ']' . $name_addition . '"' . $class . $args['attributes'] . '>' . $options . '</select>';
+		echo self::show_help( 'id-' . $args['key'], $args['help'] ) . '<select id="' . $args['label_for'] . '" name="yst_ga[ga_general][' . $args['key'] . ']' . $name_addition . '"' . $class . $args['attributes'] . '>' . $options . '</select>';
 	}
 
 	/**
@@ -126,7 +126,7 @@ class Yoast_GA_Admin_Settings_Fields {
 			}
 		}
 
-		echo self::show_help( 'id-' . $args['key'], $args['help'] ) . '<select id="ga_form_' . $args['key'] . '" name="yst_ga[ga_general][' . $args['key'] . ']"' . $class . $args['attributes'] . ' data-placeholder="' . __( 'Select a profile', 'google-analytics-for-wordpress' ) . '" ><option></option>' . $options . '</select>';
+		echo self::show_help( 'id-' . $args['key'], $args['help'] ) . '<select id="' . $args['label_for'] . '" name="yst_ga[ga_general][' . $args['key'] . ']"' . $class . $args['attributes'] . ' data-placeholder="' . __( 'Select a profile', 'google-analytics-for-wordpress' ) . '" ><option></option>' . $options . '</select>';
 	}
 
 

--- a/admin/class-admin-settings-fields.php
+++ b/admin/class-admin-settings-fields.php
@@ -39,7 +39,7 @@ class Yoast_GA_Admin_Settings_Fields {
 			$value = esc_attr( $value );
 		}
 
-		echo '<textarea name="yst_ga[ga_general][' . $args['key'] . ']" rows="5" cols="60">' . $value . '</textarea>';
+		echo '<textarea name="yst_ga[ga_general][' . $args['key'] . ']" id="' . $args['label_for'] . '" rows="5" cols="60">' . $value . '</textarea>';
 	}
 
 	/**

--- a/admin/class-admin-settings-registrar.php
+++ b/admin/class-admin-settings-registrar.php
@@ -541,6 +541,10 @@ class Yoast_GA_Admin_Settings_Registrar {
 			$args['key'] = $id;
 		}
 
+		if ( ! isset( $args['label_for'] ) ) {
+			$args['label_for'] = 'ga_form_' . $args['key'];
+		}
+
 		add_settings_field(
 			'yst_ga_' . $id,
 			$title,

--- a/admin/pages/dashboard.php
+++ b/admin/pages/dashboard.php
@@ -97,7 +97,7 @@ echo $yoast_ga_admin->content_head();
 				else {
 					?>
 					<div class="ga-form ga-form-input">
-						<label class="ga-form ga-form-checkbox-label ga-form-label-left"><?php echo __( 'Select a dimension', 'google-analytics-for-wordpress' ); ?></label>
+						<label for="toggle_dimensions" class="ga-form ga-form-checkbox-label ga-form-label-left"><?php echo __( 'Select a dimension', 'google-analytics-for-wordpress' ); ?></label>
 					</div>
 					<select data-rel='toggle_dimensions' id="toggle_dimensions" style="width: 350px"></select>
 

--- a/admin/pages/settings-api.php
+++ b/admin/pages/settings-api.php
@@ -49,8 +49,8 @@ settings_errors( 'yoast_google_analytics' );
 
 					echo '<script>yst_thickbox_heading = "' . __( 'Paste your Google authentication code', 'google-analytics-for-wordpress' ) . '";</script>';
 					echo '<div id="oauth_code" class="ga-form ga-form-input">';
-						echo '<label class="ga-form ga-form-text-label ga-form-label-left" id="yoast-ga-form-label-text-ga-authwithgoogle">' . __( 'Paste your Google code here', 'google-analytics-for-wordpress' ) . ':</label>';
-						echo '<input type="text" name="yst_ga[ga_general][google_auth_code]">';
+						echo '<label class="ga-form ga-form-text-label ga-form-label-left" id="yoast-ga-form-label-text-ga-authwithgoogle">' . __( 'Paste your Google code here', 'google-analytics-for-wordpress' ) . ':';
+						echo '<input type="text" name="yst_ga[ga_general][google_auth_code]"></label>';
 
 						echo '<label class="ga-form ga-form-text-label ga-form-label-left" id="yoast-ga-form-label-text-ga-authwithgoogle-submit">&nbsp;</label>';
 						echo '<div class="ga-form ga-form-input"><input type="submit" name="ga-form-settings" value="' . __( 'Save authentication code', 'google-analytics-for-wordpress' ) . '" class="button button-primary ga-form-submit" id="yoast-ga-form-submit-settings" onclick="yst_closepopupwindow();"></div>';

--- a/admin/pages/settings-api.php
+++ b/admin/pages/settings-api.php
@@ -51,8 +51,6 @@ settings_errors( 'yoast_google_analytics' );
 					echo '<div id="oauth_code" class="ga-form ga-form-input">';
 						echo '<label class="ga-form ga-form-text-label ga-form-label-left" id="yoast-ga-form-label-text-ga-authwithgoogle">' . __( 'Paste your Google code here', 'google-analytics-for-wordpress' ) . ':';
 						echo '<input type="text" name="yst_ga[ga_general][google_auth_code]"></label>';
-
-						echo '<label class="ga-form ga-form-text-label ga-form-label-left" id="yoast-ga-form-label-text-ga-authwithgoogle-submit">&nbsp;</label>';
 						echo '<div class="ga-form ga-form-input"><input type="submit" name="ga-form-settings" value="' . __( 'Save authentication code', 'google-analytics-for-wordpress' ) . '" class="button button-primary ga-form-submit" id="yoast-ga-form-submit-settings" onclick="yst_closepopupwindow();"></div>';
 					echo '</div>';
 

--- a/tests/test-class-admin-settings-fields.php
+++ b/tests/test-class-admin-settings-fields.php
@@ -20,9 +20,10 @@ class Yoast_GA_Admin_Form_Fields_Test extends GA_UnitTestCase {
 	 */
 	public function test_yst_ga_textarea_field_WITH_no_value() {
 		$args     = array(
-			'key' => 'test-field',
+			'key'       => 'test-field',
+			'label_for' => 'ga_form_test-field',
 		);
-		$expected = '<textarea name="yst_ga[ga_general][' . $args['key'] . ']" rows="5" cols="60"></textarea>';
+		$expected = '<textarea name="yst_ga[ga_general][' . $args['key'] . ']" id="' . $args['label_for'] . '" rows="5" cols="60"></textarea>';
 
 		$this->assertEquals( $expected, $this->helper_field_output( 'yst_ga_textarea_field', $args ) );
 	}

--- a/tests/test-class-admin-settings-fields.php
+++ b/tests/test-class-admin-settings-fields.php
@@ -7,9 +7,10 @@ class Yoast_GA_Admin_Form_Fields_Test extends GA_UnitTestCase {
 	 */
 	public function test_yst_ga_text_field_WITH_no_value() {
 		$args     = array(
-			'key' => 'test-field',
+			'key'       => 'test-field',
+			'label_for' => 'ga_form_test-field',
 		);
-		$expected = '<input type="text" name="yst_ga[ga_general][' . $args['key'] . ']" id="ga_form_' . $args['key'] . '" value="" class="ga-form-text">';
+		$expected = '<input type="text" name="yst_ga[ga_general][' . $args['key'] . ']" id="' . $args['label_for'] . '" value="" class="ga-form-text">';
 
 		$this->assertEquals( $expected, $this->helper_field_output( 'yst_ga_text_field', $args ) );
 	}
@@ -31,9 +32,10 @@ class Yoast_GA_Admin_Form_Fields_Test extends GA_UnitTestCase {
 	 */
 	public function test_yst_ga_checkbox_field_WITH_no_value() {
 		$args     = array(
-			'key' => 'test-field',
+			'key'       => 'test-field',
+			'label_for' => 'ga_form_test-field',
 		);
-		$expected = '<input type="checkbox" name="yst_ga[ga_general][' . $args['key'] . ']" id="ga_form_' . $args['key'] . '" value="1" >';
+		$expected = '<input type="checkbox" name="yst_ga[ga_general][' . $args['key'] . ']" id="' . $args['label_for'] . '" value="1" >';
 
 		$this->assertEquals( $expected, $this->helper_field_output( 'yst_ga_checkbox_field', $args ) );
 	}


### PR DESCRIPTION
This change is to address issue #313, at least for those settings rendered using the settings API with the `do_settings_sections()` function.  It looks like there may be some labeling issues which remain for input fields not using he API.

Per the Wordpress codex for `add_settings_field(...)`, the 'label_for' key
will be used to wrap a `<label>` tag around the setting `$title`. with the
value as the corresponding input field `id`.  This change adds this key so
that fields using it will be labeled when rendered.  Also, the potential
callback functions are modified to use this additional array key for
consistency.