### PR TITLE
Preventing conflicts with wpseo and limiting the number of requests.

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -15,7 +15,17 @@ class Yoast_GA_Admin extends Yoast_GA_Options {
 		parent::__construct();
 
 		add_action( 'plugins_loaded', array( $this, 'init_ga' ) );
-		add_action( 'admin_init', array( $this, 'init_settings' ) );
+
+		// Only run admin_init when there is a cron jon executed.
+		$current_page = filter_input( INPUT_GET, 'page' );
+
+		// Only when current page is not 'wpseo'.
+		if ( strpos( $current_page, 'wpseo' ) !== 0 ) {
+			if ( ( $this->is_running_cron() || $this->is_running_ajax() ) || strpos( $current_page, 'yst_ga' ) === 0 ) {
+				add_action( 'admin_init', array( $this, 'init_settings' ) );
+			}
+		}
+
 	}
 
 	/**
@@ -596,6 +606,22 @@ class Yoast_GA_Admin extends Yoast_GA_Options {
 
 			delete_transient( $transient_name );
 		}
+	}
+
+	/**
+	 * Check if there the aggregate data cron is executed
+	 * @return bool
+	 */
+	private function is_running_cron() {
+		return doing_action( 'yst_ga_aggregate_data' ) && defined( 'DOING_CRON') && DOING_CRON;
+	}
+
+	/**
+	 * Check if there the aggregate data cron is executed
+	 * @return bool
+	 */
+	private function is_running_ajax() {
+		return defined( 'DOING_AJAX') && DOING_AJAX && strpos( filter_input( INPUT_GET, 'action' ), 'yoast_dashboard' ) === 0;
 	}
 
 }

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -613,7 +613,7 @@ class Yoast_GA_Admin extends Yoast_GA_Options {
 	 * @return bool
 	 */
 	private function is_running_cron() {
-		return doing_action( 'yst_ga_aggregate_data' ) && defined( 'DOING_CRON') && DOING_CRON;
+		return doing_action( 'yst_ga_aggregate_data' ) && defined( 'DOING_CRON' ) && DOING_CRON;
 	}
 
 	/**
@@ -621,7 +621,7 @@ class Yoast_GA_Admin extends Yoast_GA_Options {
 	 * @return bool
 	 */
 	private function is_running_ajax() {
-		return defined( 'DOING_AJAX') && DOING_AJAX && strpos( filter_input( INPUT_GET, 'action' ), 'yoast_dashboard' ) === 0;
+		return defined( 'DOING_AJAX' ) && DOING_AJAX && strpos( filter_input( INPUT_GET, 'action' ), 'yoast_dashboard' ) === 0;
 	}
 
 }

--- a/admin/dashboards/class-admin-dashboards-collector.php
+++ b/admin/dashboards/class-admin-dashboards-collector.php
@@ -89,7 +89,7 @@ class Yoast_GA_Dashboards_Collector {
 		add_action( 'yst_ga_aggregate_data', array( $this, 'aggregate_data' ) );
 
 		// Check if the WP cron did run on time
-		if ( isset( $_GET['page'] ) && ( $_GET['page'] === 'yst_ga_dashboard' || $_GET['page'] === 'yst_ga_settings' ) ) {
+		if ( filter_input( INPUT_GET, 'page' ) === 'yst_ga_dashboard' ) {
 			add_action( 'shutdown', array( $this, 'check_api_call_hook' ) );
 		}
 	}


### PR DESCRIPTION
Check if current page isn't wordpress and check if current page is a Google Analytics page or if it's a cron /ajax call being executed.

Also doing the fallback of the data loading on the dashboards page. There is not need to do this when being on the settings page.

@jdevalk or @omarreiss Can one of you review this pull?