### PR TITLE
Create yst_ga_filter_ga_create_args filter

### DIFF
--- a/frontend/class-universal.php
+++ b/frontend/class-universal.php
@@ -47,24 +47,21 @@ class Yoast_GA_Universal extends Yoast_GA_Tracking {
 				return null;
 			}
 
-			// Set tracking code here
 			if ( ! empty( $ua_code ) ) {
-				if ( $this->options['add_allow_linker'] && ! $this->options['allow_anchor'] ) {
-					$gaq_push[] = "'create', '" . $ua_code . "', '" . $domain . "', {'allowLinker': true}";
+				// Prepare the arguments to be passed into the create method.
+				$create_arguments = array(
+					'trackingId' => $ua_code,
+					'cookieDomain' => $domain,
+				);
+				if ( $this->options['add_allow_linker'] ) {
+					$create_arguments['allowLinker'] = true;
 				}
-				else {
-					if ( $this->options['allow_anchor'] && ! $this->options['add_allow_linker'] ) {
-						$gaq_push[] = "'create', '" . $ua_code . "', '" . $domain . "', {'allowAnchor': true}";
-					}
-					else {
-						if ( $this->options['allow_anchor'] && $this->options['add_allow_linker'] ) {
-							$gaq_push[] = "'create', '" . $ua_code . "', '" . $domain . "', {'allowAnchor': true, 'allowLinker': true}";
-						}
-						else {
-							$gaq_push[] = "'create', '" . $ua_code . "', '" . $domain . "'";
-						}
-					}
+				if ( $this->options['allow_anchor'] ) {
+					$create_arguments['allowAnchor'] = true;
 				}
+				// Allow other plugins / themes to filter the create args.
+				$create_arguments = apply_filters( 'yst_ga_filter_ga_create_args', $create_arguments );
+				$gaq_push[] = "'create', " .  json_encode((object)$create_arguments);
 			}
 
 			$gaq_push[] = "'set', 'forceSSL', true";


### PR DESCRIPTION
The attached patch introduces a filter (yst_ga_filter_ga_create_args) that can be used to amend / add to the arguments passed when creating the tracker object. 

Among other things this allows a user to alter create-only variables such as siteSpeedSampleRate by implementing the filter, e.g.

```php
function lw_yst_ga_filter_ga_create_args($args) {
	$args['siteSpeedSampleRate'] = 100;
	return $args;
}
add_filter( 'yst_ga_filter_ga_create_args', 'lw_yst_ga_filter_ga_create_args', 10, 1 );
```

Related #316, https://wordpress.org/support/topic/unable-to-change-sample-rate-for-site-speed?replies=1